### PR TITLE
Ramusage

### DIFF
--- a/norbert/__init__.py
+++ b/norbert/__init__.py
@@ -261,8 +261,8 @@ def wiener(v, x, iterations=1, use_softmask=True, eps=None):
     # we need to refine the estimates. Scales down the estimates for
     # numerical stability
     max_abs = max(1, np.abs(x).max()/10.)
-    x_scaled = x / max_abs
-    y = expectation_maximization(y/max_abs, x_scaled, iterations, eps=eps)[0]
+    x /= max_abs
+    y = expectation_maximization(y/max_abs, x, iterations, eps=eps)[0]
     return y*max_abs
 
 

--- a/norbert/__init__.py
+++ b/norbert/__init__.py
@@ -136,7 +136,7 @@ def expectation_maximization(y, x, iterations=2, verbose=0, eps=None):
             print('EM, iteration %d' % (it+1))
 
         print('getting local gaussian models')
-        for j in trange(nb_sources):
+        for j in range(nb_sources):
             # update the spectrogram model for source j
             v[..., j], R[..., j] = get_local_gaussian_model(
                 y[..., j],
@@ -149,7 +149,7 @@ def expectation_maximization(y, x, iterations=2, verbose=0, eps=None):
             Cxx += regularization
             inv_Cxx = _invert(Cxx, eps)
             # separate the sources
-            for j in trange(nb_sources):
+            for j in range(nb_sources):
                 W_j = wiener_gain(v[None, t, ..., j], R[..., j], inv_Cxx)
                 y[t, ..., j] = apply_filter(x[None, t, ...], W_j)[0]
 

--- a/norbert/__init__.py
+++ b/norbert/__init__.py
@@ -128,23 +128,19 @@ def expectation_maximization(y, x, iterations=2, verbose=0, eps=None):
     regularization = np.sqrt(eps) * (
             np.tile(np.eye(nb_channels, dtype=np.complex64),
                     (1, nb_bins, 1, 1)))
-    from tqdm import trange
-    for it in trange(iterations):
+    for it in range(iterations):
         # constructing the mixture covariance matrix. Doing it with a loop
         # to avoid storing anytime in RAM the whole 6D tensor
         if verbose:
             print('EM, iteration %d' % (it+1))
 
-        print('getting local gaussian models')
         for j in range(nb_sources):
             # update the spectrogram model for source j
             v[..., j], R[..., j] = get_local_gaussian_model(
                 y[..., j],
                 eps)
 
-        nb_frames = x.shape[0]
-        print('now doing separation')
-        for t in trange(nb_frames):
+        for t in range(nb_frames):
             Cxx = get_mix_model(v[None, t, ...], R)
             Cxx += regularization
             inv_Cxx = _invert(Cxx, eps)

--- a/norbert/__init__.py
+++ b/norbert/__init__.py
@@ -508,12 +508,7 @@ def get_local_gaussian_model(y_j, eps=1.):
 
     v_j = np.mean(np.abs(y_j)**2, axis=2)
 
-    # compute the covariance of the source
-    #C_j = _covariance(y_j)
-
     # updates the spatial covariance matrix
-    # this is where there is a potential overflow problem for very long
-    # files, but we ignore this potential issue and let it to the user.
     nb_frames = y_j.shape[0]
     R_j = 0
     weight = eps
@@ -521,14 +516,4 @@ def get_local_gaussian_model(y_j, eps=1.):
         R_j += _covariance(y_j[None, t, ...])
         weight += v_j[None, t, ...]
     R_j /= weight[..., None, None]
-    # try:
-    #     R_j = (
-    #         np.sum(C_j, axis=0) /
-    #         (eps+np.sum(v_j[..., None, None], axis=0))
-    #     )
-    # except Exception:
-    #     raise Exception(
-    #           'There was a problem when computing the spatial covariance '
-    #           'matrix. Your mixture is probably too long for this '
-    #           'implementation')
     return v_j, R_j

--- a/norbert/__init__.py
+++ b/norbert/__init__.py
@@ -513,19 +513,26 @@ def get_local_gaussian_model(y_j, eps=1.):
     v_j = np.mean(np.abs(y_j)**2, axis=2)
 
     # compute the covariance of the source
-    C_j = _covariance(y_j)
+    #C_j = _covariance(y_j)
 
     # updates the spatial covariance matrix
     # this is where there is a potential overflow problem for very long
     # files, but we ignore this potential issue and let it to the user.
-    try:
-        R_j = (
-            np.sum(C_j, axis=0) /
-            (eps+np.sum(v_j[..., None, None], axis=0))
-        )
-    except Exception:
-        raise Exception(
-              'There was a problem when computing the spatial covariance '
-              'matrix. Your mixture is probably too long for this '
-              'implementation')
+    nb_frames = y_j.shape[0]
+    R_j = 0
+    weight = eps
+    for t in range(nb_frames):
+        R_j += _covariance(y_j[None, t, ...])
+        weight += v_j[None, t, ...]
+    R_j /= weight[..., None, None]
+    # try:
+    #     R_j = (
+    #         np.sum(C_j, axis=0) /
+    #         (eps+np.sum(v_j[..., None, None], axis=0))
+    #     )
+    # except Exception:
+    #     raise Exception(
+    #           'There was a problem when computing the spatial covariance '
+    #           'matrix. Your mixture is probably too long for this '
+    #           'implementation')
     return v_j, R_j


### PR DESCRIPTION
Made the ram usage of norbert better, by removing storage of many big arrays that were unnecessary, at the cost of some for loops. This should not seriously impact speed, but does very significantly minimize ram usage: approximately halves it.
Actually, it looks like avoiding the allocation of the big arrays does minimize running time also.


Ram usage of some oracle separation method:

before:
![wiener_before](https://user-images.githubusercontent.com/9372516/64281560-b193cf00-cf53-11e9-92d5-c81687f02267.png)

after:
![wiener_after](https://user-images.githubusercontent.com/9372516/64281570-b8224680-cf53-11e9-97d9-65f53f28e050.png)


 